### PR TITLE
Corresponded to a file with default settings

### DIFF
--- a/lib/gcp_scheduler/command.rb
+++ b/lib/gcp_scheduler/command.rb
@@ -27,10 +27,9 @@ module GcpScheduler
     end
 
     def create(scheduler_file_path:, prefix: "")
-      Scheduler.scheduler_config(scheduler_file_path)[:jobs].each do |job|
-        scheduler_name = "#{prefix}#{job[:name]}"
-        puts "Create #{scheduler_name}"
-        scheduler.create_job(name:        scheduler_name,
+      Scheduler.scheduler_config_jobs(file_path: scheduler_file_path, job_name_prefix: prefix).each do |job|
+        puts "Create #{job[:name]}"
+        scheduler.create_job(name:        job[:name],
                              description: job[:description],
                              uri:         job[:uri],
                              schedule:    job[:schedule],
@@ -38,7 +37,7 @@ module GcpScheduler
                              params:      job[:params],
                              http_method: job[:http_method],
                              headers:     job[:http_headers])
-        puts "Created #{scheduler_name}"
+        puts "Created #{job[:name]}"
       end
     end
   end

--- a/lib/gcp_scheduler/scheduler.rb
+++ b/lib/gcp_scheduler/scheduler.rb
@@ -44,10 +44,14 @@ module GcpScheduler
         http_target: {
           uri:         uri,
           http_method: http_method,
-          body:        params.to_json,
+          body:        params,
           headers:     headers
         },
       }
+
+      if params.present? && headers["Content-Type"] == "application/json"
+        job[:http_target][:body] = params.to_json
+      end
 
       client.create_job parent: parent, job: job
     end

--- a/lib/gcp_scheduler/scheduler.rb
+++ b/lib/gcp_scheduler/scheduler.rb
@@ -6,6 +6,13 @@ module GcpScheduler
       def scheduler_config(file_path)
         YAML.safe_load(ERB.new(File.read(file_path)).result, aliases: true).with_indifferent_access
       end
+
+      def scheduler_config_jobs(file_path:, job_name_prefix: "")
+        config = scheduler_config(file_path)
+        config[:jobs].map do |job|
+          (config[:defaults] || {}).merge(job.merge(name: "#{job_name_prefix}#{job[:name]}")).with_indifferent_access
+        end
+      end
     end
 
     def initialize(project:, location:)

--- a/spec/fixtures/scheduler_with_defaults.yml
+++ b/spec/fixtures/scheduler_with_defaults.yml
@@ -1,0 +1,19 @@
+defaults:
+  uri: https://yourdomain.example.com/api/v1/jobs
+  http_method: POST
+  time_zone: Asia/Tokyo
+  http_headers:
+    Authorization: 'Bearer <%= ENV["SECRET"] %>'
+    Content-Type: application/json
+
+jobs:
+  - name: WeeklyJob
+    description: 'Runs every week at 9:00 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
+    schedule: '0 9 * * *'
+    params:
+      job_name: weekly_job
+  - name: DailyJob
+    description: 'Runs every day at 10:30 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
+    schedule: '30 10 * * *'
+    params:
+      job_name: daily_job

--- a/spec/gcp_scheduler/scheduler_spec.rb
+++ b/spec/gcp_scheduler/scheduler_spec.rb
@@ -27,4 +27,60 @@ describe GcpScheduler::Scheduler do
       expect(job[:uri]).to eq("https://yourdomain.example.com/api/v1/jobs")
     end
   end
+
+  describe "#scheduler_config_jobs" do
+    before do
+      travel_to Time.parse("2023/4/1 11:00")
+      ENV["SECRET"] = "secret_key"
+    end
+
+    after do
+      travel_back
+    end
+
+    it "Configuration file with default settings" do
+      path = fixture_path("scheduler_with_defaults.yml")
+      jobs = GcpScheduler::Scheduler.scheduler_config_jobs(file_path:       path,
+                                                           job_name_prefix: "rspec-")
+
+      expect(jobs.size).to eq(2)
+      weekly_job = jobs.first
+      expect(weekly_job[:name]).to eq("rspec-WeeklyJob")
+      expect(weekly_job[:params]).to eq({ "job_name" => "weekly_job" })
+      expect(weekly_job[:description]).to eq("Runs every week at 9:00 a.m. Created:2023/04/01 11:00")
+      expect(weekly_job[:schedule]).to eq("0 9 * * *")
+
+      daily_job = jobs.last
+      expect(daily_job[:name]).to eq("rspec-DailyJob")
+      expect(daily_job[:params]).to eq({ "job_name" => "daily_job" })
+      expect(daily_job[:description]).to eq("Runs every day at 10:30 a.m. Created:2023/04/01 11:00")
+      expect(daily_job[:schedule]).to eq("30 10 * * *")
+
+      # defaults
+      jobs.each do |job|
+        expect(job[:uri]).to eq("https://yourdomain.example.com/api/v1/jobs")
+        expect(job[:http_method]).to eq("POST")
+        expect(job[:time_zone]).to eq("Asia/Tokyo")
+        http_headers = { "Authorization" => "Bearer secret_key", "Content-Type" => "application/json" }
+        expect(job[:http_headers]).to eq(http_headers)
+      end
+    end
+
+    it "Configuration file without default settings" do
+      path = fixture_path("scheduler.yml")
+      jobs = GcpScheduler::Scheduler.scheduler_config_jobs(file_path:       path,
+                                                           job_name_prefix: "rspec-")
+
+      expect(jobs.size).to eq(1)
+      job = jobs.first
+      expect(job[:name]).to eq("rspec-WeeklyJob")
+      expect(job[:description]).to eq("Runs every week at 9:00 a.m. Created:2023/04/01 11:00")
+      expect(job[:schedule]).to eq("0 9 * * *")
+      expect(job[:time_zone]).to eq("Asia/Tokyo")
+      expect(job[:uri]).to eq("https://yourdomain.example.com/api/v1/jobs")
+      expect(job[:http_method]).to eq("POST")
+      expect(job[:params]).to eq({ "job_name" => "weekly_job" })
+      expect(job[:http_headers]).to eq("Authorization" => "Bearer secret_key", "Content-Type" => "application/json")
+    end
+  end
 end


### PR DESCRIPTION
Support for the following configuration files

```yaml
defaults:
  uri: https://yourdomain.example.com/api/v1/jobs
  http_method: POST
  time_zone: Asia/Tokyo
  http_headers:
    Authorization: 'Bearer <%= ENV["SECRET"] %>'
    Content-Type: application/json

jobs:
  - name: WeeklyJob
    description: 'Runs every week at 9:00 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
    schedule: '0 9 * * *'
    params:
      job_name: weekly_job
  - name: DailyJob
    description: 'Runs every day at 10:30 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
    schedule: '30 10 * * *'
    params:
      job_name: daily_job
```

The results are as follows

```yaml
jobs:
  - name: WeeklyJob
    description: 'Runs every week at 9:00 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
    schedule: '0 9 * * *'
    params:
      job_name: weekly_job
    uri: https://yourdomain.example.com/api/v1/jobs
    http_method: POST
    time_zone: Asia/Tokyo
    http_headers:
      Authorization: 'Bearer <%= ENV["SECRET"] %>'
      Content-Type: application/json
  - name: DailyJob
    description: 'Runs every day at 10:30 a.m. Created:<%= Time.now.strftime("%Y/%m/%d %-H:%M") %>'
    schedule: '30 10 * * *'
    params:
      job_name: daily_job
    uri: https://yourdomain.example.com/api/v1/jobs
    http_method: POST
    time_zone: Asia/Tokyo
    http_headers:
      Authorization: 'Bearer <%= ENV["SECRET"] %>'
      Content-Type: application/json
```